### PR TITLE
Automatically commit scheduled updates through "base16-project-bot"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @base16-project/helix

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,24 @@
+name: Update with the latest colorschemes
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 0" # https://crontab.guru/every-week
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch the repository code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}
+      - name: Update schemes
+        uses: base16-project/base16-builder-go@latest
+      - name: Commit the changes, if any
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update with the latest colorschemes
+          branch: ${{ github.head_ref }}
+          commit_user_name: base16-project-bot
+          commit_user_email: base16themeproject@proton.me
+          commit_author: base16-project-bot <base16themeproject@proton.me>

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+schemes


### PR DESCRIPTION
- Automatically generate and commit (if necessary) themes every Sunday (It can also be manually triggered) using https://github.com/base16-project/base16-builder-go. It's set up and working on all the base16-project/base16-* template repos (https://github.com/base16-project/base16-shell/blob/main/.github/workflows/update.yml). I've already added the `secrets.BOT_ACCESS_TOKEN` to the repo action secrets.
- Add a codeowners file so the maintainers of base16-helix are automatically tagged when PRs are created.