### PR TITLE
Add ui.virutal.jump-label styling

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -71,6 +71,7 @@
 "ui.virtual.indent-guide" = { fg = "base03" }
 "ui.virtual.inlay-hint" = { fg = "base01" }
 "ui.virtual.ruler" = { bg = "base01" }
+"ui.virtual.jump-label" = { fg = "base0A", modifiers = ["bold"] }
 "ui.window" = { bg = "base01" }
 
 [palette]


### PR DESCRIPTION
Helix has introduced in [24.03 version](https://helix-editor.com/news/release-24-03-highlights/) a new jump mode and the themes need to be updated to work properly.

Related to: https://github.com/tinted-theming/base16-helix/issues/11