### PR TITLE
Use comment color for inline-hints

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -69,7 +69,7 @@
 "ui.text" = "base05"
 "ui.text.focus" = "base05"
 "ui.virtual.indent-guide" = { fg = "base03" }
-"ui.virtual.inlay-hint" = { fg = "base01" }
+"ui.virtual.inlay-hint" = { fg = "base03" }
 "ui.virtual.ruler" = { bg = "base01" }
 "ui.window" = { bg = "base01" }
 


### PR DESCRIPTION
Currently, they are a background color and unreadable 

fixes #13