### PR TITLE
Add additional markup heading levels

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -29,7 +29,12 @@
 "warning" = "base09"
 
 "markup.bold" = { fg = "base0A", modifiers = ["bold"] }
-"markup.heading" = "base0D"
+"markup.heading.1" = { fg = "base0D", modifiers = ["bold"] }
+"markup.heading.2" = { fg = "base08", modifiers = ["bold"] }
+"markup.heading.3" = { fg = "base09", modifiers = ["bold"] }
+"markup.heading.4" = { fg = "base0A", modifiers = ["bold"] }
+"markup.heading.5" = { fg = "base0B", modifiers = ["bold"] }
+"markup.heading.6" = { fg = "base0C", modifiers = ["bold"] }
 "markup.italic" = { fg = "base0E", modifiers = ["italic"] }
 "markup.link.text" = "base08"
 "markup.link.url" = { fg = "base09", modifiers = ["underlined"] }


### PR DESCRIPTION
Changelog:
- Added additional markup heading level colors `h1-h6`
- Changed default heading style to bold ~~to better align with built-in helix themes~~ EDIT: just looked at a few more examples from [helix](https://github.com/helix-editor/helix/blob/master/runtime/themes/), and it looks like bold headings are a choice made per theme. Happy to revert if unwelcome.

I preserved the `base0D` as the color for `h1` and then just incremented from `base08` for the remaining header levels. I don't particularly care about the exact colors and am happy to amend.