### PR TITLE
Update cursor colors

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -51,11 +51,11 @@
 "ui.background" = { bg = "base00" }
 "ui.bufferline.active" = { fg = "base00", bg = "base03", modifiers = ["bold"] }
 "ui.bufferline" = { fg = "base04", bg = "base00" }
-"ui.cursor" = { fg = "base0A", modifiers = ["reversed"] }
-"ui.cursor.insert" = { fg = "base0A", modifiers = ["reversed"] }
+"ui.cursor" = { fg = "base05", modifiers = ["reversed"] }
+"ui.cursor.insert" = { fg = "base05", modifiers = ["reversed"] }
 "ui.cursorline.primary" = { fg = "base05", bg = "base01" }
-"ui.cursor.match" = { fg = "base0A", modifiers = ["reversed"] }
-"ui.cursor.select" = { fg = "base0A", modifiers = ["reversed"] }
+"ui.cursor.match" = { fg = "base05", modifiers = ["reversed"] }
+"ui.cursor.select" = { fg = "base05", modifiers = ["reversed"] }
 "ui.gutter" = { bg = "base00" }
 "ui.help" = { fg = "base06", bg = "base01" }
 "ui.linenr" = { fg = "base03", bg = "base00" }

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -54,7 +54,7 @@
 "ui.cursor" = { fg = "base05", modifiers = ["reversed"] }
 "ui.cursor.insert" = { fg = "base05", modifiers = ["reversed"] }
 "ui.cursorline.primary" = { fg = "base05", bg = "base01" }
-"ui.cursor.match" = { fg = "base05", modifiers = ["reversed"] }
+"ui.cursor.match" = { fg = "base05", bg = "base02", modifiers = ["bold"] }
 "ui.cursor.select" = { fg = "base05", modifiers = ["reversed"] }
 "ui.gutter" = { bg = "base00" }
 "ui.help" = { fg = "base06", bg = "base01" }


### PR DESCRIPTION
Changelog:

- Change cursor colors from `base0A` to `base05`. This is more consistent with other base16 apps, e.g. [tinted-vim](https://github.com/tinted-theming/tinted-vim/blob/main/templates/tinted-vim.mustache)
- Visually distinguish "match" cursor from primary cursor like [tinted-vim](https://github.com/tinted-theming/tinted-vim/blob/main/templates/tinted-vim.mustache)
  - Before:
![2024-12-30-124927_hyprshot](https://github.com/user-attachments/assets/0e08afde-9208-4793-9621-7186c5e3af1f)
  - After:
![2024-12-30-124937_hyprshot](https://github.com/user-attachments/assets/74445171-9c95-4609-b361-018bde301f14)

Tried to make reasonable choices. Chose to use `bold` vs `underlined` since selection cursor is often styled as underlined. Welcome any suggested changes.