### PR TITLE
Add ui.text.directory

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -72,6 +72,7 @@
 "ui.statusline.normal" = { fg = "base00", bg = "base03" }
 "ui.statusline.select" = { fg = "base00", bg = "base0F" }
 "ui.text" = "base05"
+"ui.text.directory" = "base0D"
 "ui.text.focus" = "base05"
 "ui.virtual.indent-guide" = { fg = "base03" }
 "ui.virtual.inlay-hint" = { fg = "base03" }


### PR DESCRIPTION
Addresses #18. Chose `base0D` to be consistent with how `ls` and `stylix` color directories