### PR TITLE
Rename "attributes" to "attribute" to match helix configuration in template

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -2,7 +2,7 @@
 # Scheme author: {{scheme-author}}
 # Template author: Tinted Theming (https://github.com/tinted-theming)
 
-"attributes" = "base09"
+"attribute" = "base09"
 "comment" = { fg = "base03", modifiers = ["italic"] }
 "constant" = "base09"
 "constant.character.escape" = "base0C"


### PR DESCRIPTION
In the [helix documentation](https://docs.helix-editor.com/themes.html) the scope for attributes has the "attribute" name instead of "attributes". This pull request fixes this small issue.