### PR TITLE
Change variable.other.member color to differentiate from string

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -22,10 +22,10 @@
 "namespace" = "base0E"
 "operator" = "base05"
 "special" = "base0D"
-"string"  = "base0B"
+"string" = "base0B"
 "type" = "base0A"
 "variable" = "base08"
-"variable.other.member" = "base0B"
+"variable.other.member" = "base0D"
 "warning" = "base09"
 
 "markup.bold" = { fg = "base0A", modifiers = ["bold"] }


### PR DESCRIPTION
Change color of variable.other.member to differentiate from string.

This helps to contrast attribute names and string values in languages such as Nix.

E.g., using Catppuccin Mocha, from:
![image](https://github.com/user-attachments/assets/247e1a7b-dedc-4df2-bc5c-c08afae4340d)

To:
![image](https://github.com/user-attachments/assets/4131bba6-838b-4dcd-9245-ff8047f77184)