### PR TITLE
Add ui.virtual.whitespace to style visible whitespace characters

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -78,6 +78,7 @@
 "ui.virtual.inlay-hint" = { fg = "base03" }
 "ui.virtual.ruler" = { bg = "base01" }
 "ui.virtual.jump-label" = { fg = "base0A", modifiers = ["bold"] }
+"ui.virtual.whitespace" = { fg = "base03" }
 "ui.window" = { bg = "base01" }
 
 [palette]


### PR DESCRIPTION
Changes visible whitespace character foreground color to base03

Before:
![20250526_15h36m12s_grim](https://github.com/user-attachments/assets/ef46d4ca-f29c-457a-aa35-1d1bc5cd7e25)

After:
![20250526_15h44m49s_grim](https://github.com/user-attachments/assets/bedfad5d-43f7-4933-8670-6a0bfae07fa7)
