### PR TITLE
Adding missing tag color

### DIFF
--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -23,6 +23,7 @@
 "operator" = "base05"
 "special" = "base0D"
 "string" = "base0B"
+"tag" = "base08"
 "type" = "base0A"
 "variable" = "base08"
 "variable.other.member" = "base0D"


### PR DESCRIPTION
According to the base16 standard xml-tag should be rendered using base08. Helix supports tags according to there
[docs](https://docs.helix-editor.com/themes.html).

I tested it locally, and now Tags are rendered. 

Before:

<img width="1437" height="1150" alt="image" src="https://github.com/user-attachments/assets/726cce8d-4de1-4f80-8300-09c611aa19f1" />

After:

<img width="1447" height="832" alt="image" src="https://github.com/user-attachments/assets/547181a9-4142-41fb-ac84-b9f14a751ae5" />
